### PR TITLE
make AWS_PROFILE configurable

### DIFF
--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -2,6 +2,7 @@
 ## AWS config
 ##################################################
 provider "aws" {
+  profile = "${var.aws_profile}"
   region = "${var.aws_region}"
 }
 

--- a/cloudfront/variables.tf
+++ b/cloudfront/variables.tf
@@ -7,6 +7,12 @@ variable "aws_region" {
   description = "The AWS Region"
 }
 
+variable "aws_profile" {
+  type    = "string"
+  default = "default"
+  description = "The AWS Profile credentials profile"
+}
+
 # Application
 variable "service_name" {
   type    = "string"

--- a/eb-env/main.tf
+++ b/eb-env/main.tf
@@ -2,6 +2,7 @@
 ## AWS config
 ##################################################
 provider "aws" {
+  profile = "${var.aws_profile}"
   region = "${var.aws_region}"
 }
 

--- a/eb-env/variables.tf
+++ b/eb-env/variables.tf
@@ -7,6 +7,12 @@ variable "aws_region" {
   description = "The AWS Region"
 }
 
+variable "aws_profile" {
+  type    = "string"
+  default = "default"
+  description = "The AWS Profile credentials profile"
+}
+
 # Application
 variable "service_name" {
   type    = "string"


### PR DESCRIPTION
We like to use this variable instead of setting AWS_PROFILE in the env. So I made it a terraform variable which defaults to `"default"`